### PR TITLE
Integrate Pareto frontier analysis and plotting

### DIFF
--- a/CDP/ConstructiveHeuristic.py
+++ b/CDP/ConstructiveHeuristic.py
@@ -46,6 +46,7 @@ class ConstructiveHeuristic:
             self.instance.capacities[edge.vertex2],
         )
         self.max_min_distance = edge.distance
+        solution.evaluate_symmetry()
         return solution
 
     def weighted_score(self, distance: float, capacity: float) -> float:
@@ -119,6 +120,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_candidate_list(solution, candidate_list, candidate.vertex)
+        solution.evaluate_symmetry()
         return solution
 
     # ------------------------------------------------------------------
@@ -134,6 +136,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_candidate_list(solution, candidate_list, candidate.vertex)
+        solution.evaluate_symmetry()
         return solution, candidate_list
 
     def construct_biased_capacity_solution(self) -> Tuple[Solution, List[WeightedCandidate]]:
@@ -149,6 +152,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
+        solution.evaluate_symmetry()
         return solution, candidate_list
 
     def construct_biased_fixed_weight_solution(self, weight: float) -> Tuple[Solution, List[WeightedCandidate]]:
@@ -164,6 +168,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
+        solution.evaluate_symmetry()
         return solution, candidate_list
 
     def construct_biased_distribution_solution(
@@ -195,6 +200,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
+        solution.evaluate_symmetry()
         return solution, candidate_list, selected_interval
 
     # ------------------------------------------------------------------

--- a/CDP/Instance.py
+++ b/CDP/Instance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from objects import Edge
 
@@ -14,12 +14,16 @@ class Instance:
     """Encapsulates all the data required to evaluate a solution."""
 
     path: str
+    colours: List[str] = field(default_factory=list)
+    lambda_penalty: float = 0.0
+    gamma_override: Optional[float] = None
     name: str = field(init=False)
     node_count: int = field(init=False, default=0)
     min_capacity: float = field(init=False, default=0)
     capacities: List[float] = field(init=False, default_factory=list)
     distances: List[List[float]] = field(init=False, default_factory=list)
     sorted_edges: List[Edge] = field(init=False, default_factory=list)
+    _min_positive_distance: Optional[float] = field(init=False, default=None, repr=False)
 
     def __post_init__(self) -> None:
         self.name = Path(self.path).name
@@ -53,4 +57,106 @@ class Instance:
                     self.sorted_edges.append(Edge(row_index, column_index, distance))
 
         self.sorted_edges.sort(key=lambda edge: edge.distance, reverse=True)
+
+    # ------------------------------------------------------------------
+    # Symmetry helpers
+    # ------------------------------------------------------------------
+    def assign_colours(self, colours: Sequence[str]) -> None:
+        """Assign a colour label to every vertex in the instance."""
+
+        if len(colours) != self.node_count:
+            raise ValueError("Number of colours must match the number of vertices.")
+        self.colours = list(colours)
+
+    def set_symmetry_parameters(
+        self, *, lambda_penalty: float, gamma_override: Optional[float] = None
+    ) -> None:
+        """Configure the symmetry penalty scaling parameters."""
+
+        if lambda_penalty < 0:
+            raise ValueError("lambda_penalty must be non-negative.")
+        if gamma_override is not None and gamma_override < 0:
+            raise ValueError("gamma_override must be non-negative when provided.")
+        self.lambda_penalty = lambda_penalty
+        self.gamma_override = gamma_override
+        self._min_positive_distance = None
+
+    def min_positive_distance(self) -> float:
+        """Return the minimum strictly positive distance among vertices."""
+
+        if self._min_positive_distance is None:
+            positive = [edge.distance for edge in self.sorted_edges if edge.distance > 0]
+            if not positive:
+                raise ValueError("Instance must contain at least one positive distance.")
+            self._min_positive_distance = min(positive)
+        return self._min_positive_distance
+
+    @property
+    def gamma(self) -> float:
+        """Scaling factor used by the linear symmetry penalty."""
+
+        if self.gamma_override is not None:
+            return self.gamma_override
+        if self.lambda_penalty == 0:
+            return 0.0
+        return self.lambda_penalty * self.min_positive_distance()
+
+    def _ordered_active_colours(self, selected_vertices: Sequence[int]) -> List[str]:
+        """Return active colours ordered by the lowest-index vertex using them."""
+
+        colour_first_index: Dict[str, int] = {}
+        for vertex in selected_vertices:
+            colour = self.colours[vertex]
+            if colour not in colour_first_index or vertex < colour_first_index[colour]:
+                colour_first_index[colour] = vertex
+        ordered = [
+            colour
+            for colour, _ in sorted(colour_first_index.items(), key=lambda item: item[1])
+        ]
+        return ordered
+
+    def colour_pair_coefficients(
+        self, selected_vertices: Sequence[int]
+    ) -> Dict[Tuple[str, str], float]:
+        """Return the per-colour coefficients contributing to the penalty.
+
+        Colours are made distinct by vertex index, so the earliest colour present
+        in the selection is treated as the reference tone. Each additional active
+        colour contributes ``gamma`` to the total penalty and is reported as a
+        pair ``(reference_colour, new_colour)``.
+        """
+
+        if not selected_vertices or not self.colours:
+            return {}
+        ordered_colours = self._ordered_active_colours(selected_vertices)
+        if len(ordered_colours) <= 1:
+            return {}
+        reference_colour = ordered_colours[0]
+        coefficients: Dict[Tuple[str, str], float] = {}
+        for colour in ordered_colours[1:]:
+            coefficients[(reference_colour, colour)] = self.gamma
+        return coefficients
+
+    def symmetry_penalty(
+        self,
+        selected_vertices: Sequence[int],
+        *,
+        return_breakdown: bool = False,
+    ) -> float | Tuple[float, Dict[Tuple[str, str], float]]:
+        """Compute the linear colour penalty for a set of vertices.
+
+        When ``return_breakdown`` is enabled the method also returns the
+        per-colour coefficients explaining how the penalty was accumulated.
+        """
+
+        if not selected_vertices or not self.colours:
+            return (0.0, {}) if return_breakdown else 0.0
+        active_colours = {self.colours[vertex] for vertex in selected_vertices}
+        if len(active_colours) <= 1:
+            return (0.0, {}) if return_breakdown else 0.0
+        penalty = self.gamma * (len(active_colours) - 1)
+        if not return_breakdown:
+            return penalty
+        breakdown = self.colour_pair_coefficients(selected_vertices)
+        return penalty, breakdown
 

--- a/CDP/LocalSearches.py
+++ b/CDP/LocalSearches.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import List, Tuple
 
 from ConstructiveHeuristic import ConstructiveHeuristic
@@ -27,12 +28,25 @@ def tabu_search(
         current_solution.reevaluate()
         heuristic.insert_candidate(candidate_list, current_solution, removed_vertex)
 
-        if current_solution.objective_value > best_solution.objective_value:
+        improved_dispersion = (
+            current_solution.objective_value > best_solution.objective_value + 1e-9
+        )
+        same_dispersion = math.isclose(
+            current_solution.objective_value,
+            best_solution.objective_value,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        )
+        better_symmetry = (
+            current_solution.symmetry_penalty < best_solution.symmetry_penalty - 1e-9
+        )
+        if improved_dispersion or (same_dispersion and better_symmetry):
             best_solution = current_solution.copy()
             iterations_without_improvement = 0
         else:
             iterations_without_improvement += 1
 
+    best_solution.reevaluate()
     return best_solution, candidate_list
 
 
@@ -54,12 +68,25 @@ def tabu_search_capacity(
         current_solution.reevaluate()
         heuristic.insert_weighted_candidate(candidate_list, current_solution, removed_vertex)
 
-        if current_solution.objective_value > best_solution.objective_value:
+        improved_dispersion = (
+            current_solution.objective_value > best_solution.objective_value + 1e-9
+        )
+        same_dispersion = math.isclose(
+            current_solution.objective_value,
+            best_solution.objective_value,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        )
+        better_symmetry = (
+            current_solution.symmetry_penalty < best_solution.symmetry_penalty - 1e-9
+        )
+        if improved_dispersion or (same_dispersion and better_symmetry):
             best_solution = current_solution.copy()
             iterations_without_improvement = 0
         else:
             iterations_without_improvement += 1
 
+    best_solution.reevaluate()
     return best_solution, candidate_list
 
 

--- a/CDP/symmetry_integration.py
+++ b/CDP/symmetry_integration.py
@@ -1,0 +1,227 @@
+"""Utilities to combine CDP heuristics with the symmetry-aware toolkit."""
+
+from __future__ import annotations
+
+import math
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from Instance import Instance
+from Solution import Solution
+from cdp_symmetry import (
+    CandidateSolution,
+    EpsilonConstraintSolver,
+    Node,
+    ProblemInstance,
+    evaluate_subset,
+)
+
+try:  # pragma: no cover - optional dependency for plotting
+    import matplotlib.pyplot as plt
+except ImportError:  # pragma: no cover - optional dependency
+    plt = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class SymmetryAnalysis:
+    """Container gathering the different symmetry evaluations for a solution."""
+
+    base_solution: CandidateSolution
+    epsilon_front: List[CandidateSolution]
+
+
+def _build_nodes(instance: Instance) -> List[Node]:
+    colours = instance.colours if instance.colours else ["default" for _ in range(instance.node_count)]
+    return [
+        Node(
+            node_id=str(index),
+            capacity=instance.capacities[index],
+            color=colours[index],
+            coordinates=(float(index), 0.0),
+        )
+        for index in range(instance.node_count)
+    ]
+
+
+def _build_distances(instance: Instance) -> dict[Tuple[str, str], float]:
+    distances: dict[Tuple[str, str], float] = {}
+    for i in range(instance.node_count):
+        for j in range(instance.node_count):
+            if i == j:
+                continue
+            value = instance.distances[i][j]
+            if value:
+                distances[(str(i), str(j))] = value
+    return distances
+
+
+def build_problem_instance(instance: Instance) -> ProblemInstance:
+    """Translate a :class:`Instance` into the symmetry-aware representation."""
+
+    return ProblemInstance(
+        nodes=_build_nodes(instance),
+        demand=instance.min_capacity,
+        lambda_penalty=instance.lambda_penalty,
+        distances=_build_distances(instance),
+        gamma_override=instance.gamma_override,
+    )
+
+
+def evaluate_solution_with_symmetry(instance: Instance, solution: Solution) -> CandidateSolution:
+    """Return the symmetry-aware evaluation of a CDP solution."""
+
+    problem_instance = build_problem_instance(instance)
+    subset = tuple(str(vertex) for vertex in solution.selected_vertices)
+    candidate = evaluate_subset(problem_instance, subset)
+    penalty, breakdown = instance.symmetry_penalty(
+        solution.selected_vertices, return_breakdown=True
+    )
+    solution.symmetry_penalty = penalty
+    solution.symmetry_breakdown = breakdown
+    return candidate
+
+
+def candidate_to_solution(instance: Instance, candidate: CandidateSolution) -> Solution:
+    """Convert a symmetry candidate into the native :class:`Solution` object."""
+
+    new_solution = Solution(instance)
+    new_solution.selected_vertices = [int(node_id) for node_id in candidate.selected_nodes]
+    new_solution.capacity = sum(instance.capacities[vertex] for vertex in new_solution.selected_vertices)
+    new_solution.reevaluate()
+    return new_solution
+
+
+def generate_epsilon_front(
+    instance: Instance,
+    solution: Solution,
+    *,
+    steps: int = 5,
+) -> List[CandidateSolution]:
+    """Enumerate epsilon-constrained solutions favouring higher symmetry.
+
+    The routine starts from the symmetry penalty yielded by the provided
+    ``solution`` (typically built without considering symmetry in its
+    objective) and iteratively tightens the epsilon constraint so that each
+    subsequent candidate enjoys the same or a better symmetry level (i.e. a
+    lower penalty). Repeated solutions are discarded so the returned list
+    traces a Pareto frontier ordered by the progressively stricter symmetry
+    requirement.
+    """
+
+    base_candidate = evaluate_solution_with_symmetry(instance, solution)
+    if steps <= 0:
+        raise ValueError("steps must be strictly positive.")
+
+    solver = EpsilonConstraintSolver(build_problem_instance(instance))
+    front: List[CandidateSolution] = []
+    seen: set[Tuple[str, ...]] = {base_candidate.selected_nodes}
+
+    penalty = max(base_candidate.symmetry_penalty, 0.0)
+    if math.isclose(penalty, 0.0, abs_tol=1e-12):
+        targets = [0.0] * steps
+    else:
+        step = penalty / steps
+        targets = [max(penalty - step * (index + 1), 0.0) for index in range(steps)]
+
+    for epsilon in targets:
+        try:
+            candidate = solver.solve_max_dispersion(epsilon=epsilon)
+        except ValueError:
+            continue
+        if candidate.selected_nodes in seen:
+            continue
+        seen.add(candidate.selected_nodes)
+        front.append(candidate)
+    return front
+
+
+def analyse_solution(instance: Instance, solution: Solution, *, steps: int = 5) -> SymmetryAnalysis:
+    """Produce a detailed symmetry report for the provided solution."""
+
+    base = evaluate_solution_with_symmetry(instance, solution)
+    front = generate_epsilon_front(instance, solution, steps=steps)
+    return SymmetryAnalysis(base_solution=base, epsilon_front=front)
+
+
+def pareto_points_to_rows(candidates: Iterable[CandidateSolution]) -> List[Tuple[float, float]]:
+    """Return dispersion/penalty pairs for the provided candidates."""
+
+    rows: List[Tuple[float, float]] = []
+    for candidate in candidates:
+        dispersion = (
+            candidate.dispersion if math.isfinite(candidate.dispersion) else 0.0
+        )
+        rows.append((dispersion, candidate.symmetry_penalty))
+    return rows
+
+
+def plot_pareto_front(
+    base_candidate: CandidateSolution,
+    frontier: Iterable[CandidateSolution],
+    output_path: Path,
+) -> Path:
+    """Create a scatter plot displaying the Pareto frontier.
+
+    Parameters
+    ----------
+    base_candidate:
+        Solution generated without symmetry pressure. It is highlighted as the
+        starting point in the plot.
+    frontier:
+        Iterable describing the progressive improvements in symmetry obtained
+        through tightened epsilon constraints.
+    output_path:
+        Destination for the generated image.
+    """
+
+    if plt is None:  # pragma: no cover - plotting is optional
+        raise RuntimeError(
+            "matplotlib is required for plotting the Pareto frontier. "
+            "Install it via 'pip install matplotlib'."
+        )
+
+    rows = pareto_points_to_rows([base_candidate, *frontier])
+    if not rows:
+        raise ValueError("No candidate data available to plot the Pareto frontier.")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    plt.figure(figsize=(8, 5))
+    dispersions = [row[0] for row in rows]
+    penalties = [row[1] for row in rows]
+    plt.plot(dispersions, penalties, marker="o", linestyle="-", color="#1f77b4")
+    plt.scatter(
+        dispersions[0],
+        penalties[0],
+        color="#d62728",
+        marker="s",
+        s=120,
+        label="Sin simetría",
+        zorder=3,
+    )
+    if len(rows) > 1:
+        plt.scatter(
+            dispersions[1:],
+            penalties[1:],
+            color="#2ca02c",
+            marker="o",
+            s=80,
+            label="Restricciones ε",
+            zorder=3,
+        )
+    plt.xlabel("Dispersión")
+    plt.ylabel("Penalización de simetría")
+    plt.title("Frontera de Pareto CDP-Simetría")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.legend(loc="best")
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+    return output_path.resolve()
+

--- a/test/test_symmetry_integration.py
+++ b/test/test_symmetry_integration.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT / "CDP"))
+
+from Instance import Instance
+from Solution import Solution
+from symmetry_integration import (
+    analyse_solution,
+    pareto_points_to_rows,
+    plot_pareto_front,
+)
+
+try:  # pragma: no cover - optional dependency for plotting
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - optional dependency
+    plt = None  # type: ignore[assignment]
+
+
+class TestSymmetryIntegration(unittest.TestCase):
+    """Validate the integration between stochastic CDP heuristics and symmetry tools."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        instance_path = ROOT / "CDP" / "sample_instance.txt"
+        cls.instance = Instance(str(instance_path))
+        cls.instance.assign_colours(["red", "red", "green"])
+        cls.instance.set_symmetry_parameters(lambda_penalty=0.2)
+
+    def test_solution_symmetry_penalty(self) -> None:
+        solution = Solution(self.instance)
+        for vertex in range(self.instance.node_count):
+            solution.add_vertex(vertex)
+        solution.reevaluate()
+        expected_penalty = self.instance.gamma * (
+            len({self.instance.colours[v] for v in solution.selected_vertices}) - 1
+        )
+        self.assertAlmostEqual(solution.symmetry_penalty, expected_penalty, places=6)
+        self.assertEqual(
+            solution.symmetry_breakdown,
+            {("red", "green"): expected_penalty} if expected_penalty else {},
+        )
+
+    def test_colour_pair_coefficients(self) -> None:
+        solution = Solution(self.instance)
+        solution.add_vertex(0)
+        solution.add_vertex(2)
+        solution.evaluate_symmetry()
+        self.assertEqual(solution.symmetry_breakdown, {("red", "green"): self.instance.gamma})
+
+    def test_analyse_solution_returns_epsilon_front(self) -> None:
+        solution = Solution(self.instance)
+        solution.add_vertex(0)
+        solution.add_vertex(2)
+        solution.reevaluate()
+        analysis = analyse_solution(self.instance, solution, steps=4)
+        penalties = [candidate.symmetry_penalty for candidate in analysis.epsilon_front]
+        self.assertTrue(penalties)
+        self.assertIn(0.0, penalties)
+
+    def test_iterative_front_monotonic_penalty(self) -> None:
+        solution = Solution(self.instance)
+        solution.selected_vertices = [0, 1]
+        solution.reevaluate()
+        analysis = analyse_solution(self.instance, solution, steps=5)
+        penalties = [
+            analysis.base_solution.symmetry_penalty,
+            *[candidate.symmetry_penalty for candidate in analysis.epsilon_front],
+        ]
+        for previous, current in zip(penalties, penalties[1:]):
+            self.assertLessEqual(current + 1e-9, previous)
+
+    @unittest.skipIf(plt is None, "matplotlib not available in test environment")
+    def test_plot_pareto_front_creates_image(self) -> None:
+        solution = Solution(self.instance)
+        solution.selected_vertices = [0, 1, 2]
+        solution.reevaluate()
+        analysis = analyse_solution(self.instance, solution, steps=3)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = Path(tmp_dir) / "pareto.png"
+            generated = plot_pareto_front(
+                analysis.base_solution,
+                analysis.epsilon_front,
+                output_path,
+            )
+            self.assertTrue(generated.exists())
+            points = pareto_points_to_rows([analysis.base_solution, *analysis.epsilon_front])
+            self.assertTrue(points)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add iterative epsilon-front generation utilities and optional Pareto plotting helpers to the symmetry integration module
- extend the main driver to print Pareto frontier progress, enforce iterative symmetry constraints, and emit a plot when matplotlib is available
- cover the new workflow with regression tests, including optional plotting checks that reuse the bundled sample instance

## Testing
- python -m unittest -v
- python -m unittest discover -s test -v

------
https://chatgpt.com/codex/tasks/task_e_68ea178c997c832ba27ae3889263e97b