### PR TITLE
Add weighted Pareto frontier with symmetry objective axes

### DIFF
--- a/test/test_symmetry_integration.py
+++ b/test/test_symmetry_integration.py
@@ -12,6 +12,8 @@ from Instance import Instance
 from Solution import Solution
 from symmetry_integration import (
     analyse_solution,
+    default_alpha_schedule,
+    generate_weighted_front,
     pareto_points_to_rows,
     plot_pareto_front,
 )
@@ -62,6 +64,8 @@ class TestSymmetryIntegration(unittest.TestCase):
         penalties = [candidate.symmetry_penalty for candidate in analysis.epsilon_front]
         self.assertTrue(penalties)
         self.assertIn(0.0, penalties)
+        self.assertTrue(analysis.weighted_front)
+        self.assertAlmostEqual(sum(analysis.weighted_front[0].alpha_pair), 1.0)
 
     def test_iterative_front_monotonic_penalty(self) -> None:
         solution = Solution(self.instance)
@@ -83,14 +87,44 @@ class TestSymmetryIntegration(unittest.TestCase):
         analysis = analyse_solution(self.instance, solution, steps=3)
         with tempfile.TemporaryDirectory() as tmp_dir:
             output_path = Path(tmp_dir) / "pareto.png"
+            weighted_candidates = [entry.candidate for entry in analysis.weighted_front]
+            alpha_labels = [
+                f"α=({entry.alpha_pair[0]:.2f}, {entry.alpha_pair[1]:.2f})"
+                for entry in analysis.weighted_front
+            ]
+            base_candidate = (
+                weighted_candidates[0] if weighted_candidates else analysis.base_solution
+            )
+            frontier = (
+                weighted_candidates[1:] if weighted_candidates else analysis.epsilon_front
+            )
             generated = plot_pareto_front(
-                analysis.base_solution,
-                analysis.epsilon_front,
+                base_candidate,
+                frontier,
                 output_path,
+                alpha_labels=alpha_labels if weighted_candidates else None,
             )
             self.assertTrue(generated.exists())
-            points = pareto_points_to_rows([analysis.base_solution, *analysis.epsilon_front])
+            points = pareto_points_to_rows([base_candidate, *frontier])
             self.assertTrue(points)
+            first_penalty, first_dispersion = points[0]
+            self.assertGreaterEqual(first_penalty, 0.0)
+            self.assertGreaterEqual(first_dispersion, 0.0)
+
+    def test_default_alpha_schedule_generates_expected_pairs(self) -> None:
+        schedule = default_alpha_schedule(step=0.25)
+        self.assertEqual(schedule[0], (1.0, 0.0))
+        self.assertIn((0.5, 0.5), schedule)
+        self.assertEqual(schedule[-1], (0.0, 1.0))
+
+    def test_generate_weighted_front_respects_alpha_pairs(self) -> None:
+        schedule = [(1.0, 0.0), (0.5, 0.5), (0.0, 1.0)]
+        front = generate_weighted_front(self.instance, schedule)
+        self.assertTrue(front)
+        self.assertAlmostEqual(sum(front[0].alpha_pair), 1.0)
+        self.assertEqual(front[0].alpha_pair, schedule[0])
+        produced_pairs = {entry.alpha_pair for entry in front}
+        self.assertIn(schedule[-1], produced_pairs)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add weighted-front generation utilities that explore decreasing α pairs and expose them through the symmetry analysis results
- orient the Pareto plot around symmetry (x) versus CDP dispersion (y), annotate each point with its α weights, and update the console summaries accordingly
- extend integration tests to cover the new weighted frontier helpers and plotting behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ea3ecabbec832bb947528b3c26826b