### PR TITLE
Simplify weight handling and record Pareto history

### DIFF
--- a/CDP/ConstructiveHeuristic.py
+++ b/CDP/ConstructiveHeuristic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import random
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from Instance import Instance
 from Solution import Solution
@@ -22,12 +22,15 @@ class ConstructiveHeuristic:
         instance: Instance,
         weight: float,
     ) -> None:
+        if not 0.0 <= alpha <= 1.0:
+            raise ValueError("alpha must belong to [0, 1].")
+        if not 0.0 <= weight <= 1.0:
+            raise ValueError("weight must belong to [0, 1].")
         self.alpha = alpha
         self.beta = beta_construction
         self.beta_local_search = beta_local_search
         self.instance = instance
-        self.configured_weight: Optional[float] = weight if 0.0 <= weight <= 1.0 else None
-        self.weight = self.configured_weight if self.configured_weight is not None else weight
+        self.weight = weight
         self.first_edge_index = 0
         self.max_min_distance = 1.0
         self.max_capacity = max(instance.capacities)
@@ -46,7 +49,7 @@ class ConstructiveHeuristic:
             self.instance.capacities[edge.vertex2],
         )
         self.max_min_distance = edge.distance
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution
 
     def colour_penalty(self, solution: Solution, vertex: int) -> int:
@@ -61,12 +64,6 @@ class ConstructiveHeuristic:
         capacity_component = capacity / self.max_capacity if self.max_capacity else 0.0
         base_score = distance_component * self.weight + capacity_component * (1 - self.weight)
         return base_score * self.alpha - different_colour * (1 - self.alpha)
-
-    def apply_configured_weight(self, lower: float = 0.6, upper: float = 0.9) -> None:
-        if self.configured_weight is not None:
-            self.weight = self.configured_weight
-        else:
-            self.weight = random.uniform(lower, upper)
 
     def build_candidate_list(self, solution: Solution) -> List[Candidate]:
         candidates: List[Candidate] = []
@@ -133,7 +130,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_candidate_list(solution, candidate_list, candidate.vertex)
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution
 
     # ------------------------------------------------------------------
@@ -149,12 +146,11 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_candidate_list(solution, candidate_list, candidate.vertex)
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution, candidate_list
 
     def construct_biased_capacity_solution(self) -> Tuple[Solution, List[WeightedCandidate]]:
         solution = self.initial_solution()
-        self.apply_configured_weight(0.6, 0.9)
         candidate_list = self.build_weighted_candidate_list(solution)
 
         while not solution.is_feasible():
@@ -165,11 +161,13 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution, candidate_list
 
     def construct_biased_fixed_weight_solution(self, weight: float) -> Tuple[Solution, List[WeightedCandidate]]:
         solution = self.initial_solution()
+        if not 0.0 <= weight <= 1.0:
+            raise ValueError("weight must belong to [0, 1].")
         self.weight = weight
         candidate_list = self.build_weighted_candidate_list(solution)
 
@@ -181,7 +179,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution, candidate_list
 
     def construct_biased_distribution_solution(
@@ -189,20 +187,10 @@ class ConstructiveHeuristic:
     ) -> Tuple[Solution, List[WeightedCandidate], Tuple[float, float]]:
         solution = self.initial_solution()
 
-        random_value = random.random()
-        cumulative = 0.0
-        selected_interval = next(reversed(distribution))
-        for interval, probability in distribution.items():
-            cumulative += probability
-            if random_value <= cumulative:
-                selected_interval = interval
-                break
-
+        selected_interval = next(iter(distribution)) if distribution else (0.0, 1.0)
         lower, upper = selected_interval
-        if self.configured_weight is not None:
-            self.weight = self.configured_weight
-        else:
-            self.weight = random.uniform(lower, upper if upper <= 1 else 1)
+        if not 0.0 <= self.weight <= 1.0:
+            self.weight = max(min(upper, 1.0), lower)
         candidate_list = self.build_weighted_candidate_list(solution)
 
         while not solution.is_feasible():
@@ -213,7 +201,7 @@ class ConstructiveHeuristic:
             if candidate.distance < solution.objective_value:
                 solution.update_objective(candidate.vertex, candidate.nearest_vertex, candidate.distance)
             self.update_weighted_candidate_list(solution, candidate_list, candidate.vertex)
-        solution.evaluate_symmetry()
+        solution.reevaluate(self.alpha)
         return solution, candidate_list, selected_interval
 
     # ------------------------------------------------------------------

--- a/CDP/LocalSearches.py
+++ b/CDP/LocalSearches.py
@@ -17,7 +17,9 @@ def tabu_search(
     heuristic: ConstructiveHeuristic,
 ) -> Tuple[Solution, List[Candidate]]:
     best_solution = initial_solution.copy()
+    best_solution.reevaluate(heuristic.alpha)
     current_solution = initial_solution.copy()
+    current_solution.reevaluate(heuristic.alpha)
     iterations_without_improvement = 0
 
     while iterations_without_improvement < max_iterations:
@@ -25,7 +27,7 @@ def tabu_search(
         current_solution.remove_vertex(removed_vertex)
         heuristic.recalculate_candidate_list(current_solution, candidate_list, removed_vertex)
         current_solution = heuristic.partial_reconstruction(current_solution, candidate_list)
-        current_solution.reevaluate()
+        current_solution.reevaluate(heuristic.alpha)
         heuristic.insert_candidate(candidate_list, current_solution, removed_vertex)
 
         improved_dispersion = (
@@ -46,7 +48,7 @@ def tabu_search(
         else:
             iterations_without_improvement += 1
 
-    best_solution.reevaluate()
+    best_solution.reevaluate(heuristic.alpha)
     return best_solution, candidate_list
 
 
@@ -57,7 +59,9 @@ def tabu_search_capacity(
     heuristic: ConstructiveHeuristic,
 ) -> Tuple[Solution, List[WeightedCandidate]]:
     best_solution = initial_solution.copy()
+    best_solution.reevaluate(heuristic.alpha)
     current_solution = initial_solution.copy()
+    current_solution.reevaluate(heuristic.alpha)
     iterations_without_improvement = 0
 
     while iterations_without_improvement < max_iterations:
@@ -65,7 +69,7 @@ def tabu_search_capacity(
         current_solution.remove_vertex(removed_vertex)
         heuristic.recalculate_weighted_candidate_list(current_solution, candidate_list, removed_vertex)
         current_solution = heuristic.partial_reconstruction_capacity(current_solution, candidate_list)
-        current_solution.reevaluate()
+        current_solution.reevaluate(heuristic.alpha)
         heuristic.insert_weighted_candidate(candidate_list, current_solution, removed_vertex)
 
         improved_dispersion = (
@@ -86,7 +90,7 @@ def tabu_search_capacity(
         else:
             iterations_without_improvement += 1
 
-    best_solution.reevaluate()
+    best_solution.reevaluate(heuristic.alpha)
     return best_solution, candidate_list
 
 

--- a/CDP/Main.py
+++ b/CDP/Main.py
@@ -190,61 +190,42 @@ def deterministic_multi_start(
     initial: Tuple[Solution, List[WeightedCandidate]],
     test_case: TestCase,
     heuristic: ConstructiveHeuristic,
+    alpha: float,
 ) -> Tuple[Solution, List[WeightedCandidate]]:
     initial_solution, initial_candidates = initial
-    if 0.0 <= test_case.weight <= 1.0:
-        weight_samples = {test_case.weight: 0.0}
-    else:
-        weight_samples = {step / 10: 0.0 for step in range(5, 11)}
-
-    for _ in range(10):
-        for weight in weight_samples:
-            candidate_solution, _ = heuristic.construct_biased_fixed_weight_solution(weight)
-            weight_samples[weight] += candidate_solution.objective_value
-
-    ranked_weights = sorted(weight_samples.items(), key=lambda item: item[1], reverse=True)
-    weight_options = [ranked_weights[i][0] for i in range(min(3, len(ranked_weights)))]
+    initial_solution.reevaluate(alpha)
     best_solution = initial_solution.copy()
+    best_solution.reevaluate(alpha)
     best_candidates = clone_weighted_candidates(initial_candidates)
 
     start = time.process_time()
     while time.process_time() - start < test_case.max_time:
-        if 0.0 <= test_case.weight <= 1.0:
-            sampled_weight = test_case.weight
-        else:
-            random_value = random.random()
-            if random_value < 0.7:
-                reference = weight_options[0]
-            elif random_value < 0.9 and len(weight_options) > 1:
-                reference = weight_options[1]
-            else:
-                reference = weight_options[min(2, len(weight_options) - 1)]
-
-            lower = max(reference - 0.05, 0.0)
-            upper = min(reference + 0.05, 1.0)
-            sampled_weight = random.uniform(lower, upper)
-
-        candidate_solution, candidate_list = heuristic.construct_biased_fixed_weight_solution(sampled_weight)
+        candidate_solution, candidate_list = heuristic.construct_biased_fixed_weight_solution(
+            heuristic.weight
+        )
+        candidate_solution.reevaluate(alpha)
         candidate_solution, candidate_list = tabu_search_capacity(
             candidate_solution,
             candidate_list,
             test_case.max_iterations,
             heuristic,
         )
+        candidate_solution.reevaluate(alpha)
 
-        if candidate_solution.objective_value > best_solution.objective_value:
+        if candidate_solution.objective_value > best_solution.objective_value + 1e-9:
             best_solution = candidate_solution.copy()
             best_solution.time = time.process_time() - start
+            best_solution.reevaluate(alpha)
             best_candidates = clone_weighted_candidates(candidate_list)
 
     if best_solution.time == 0.0:
         best_solution.time = time.process_time() - start
 
-    best_solution.reevaluate()
+    best_solution.reevaluate(alpha)
     return best_solution, best_candidates
 
 
-def execute_test_case(test_case: TestCase) -> Tuple[Solution, List[WeightedCandidate]]:
+def execute_test_case(test_case: TestCase, alpha: float) -> Tuple[Solution, List[WeightedCandidate]]:
     instance_path = test_case.instance_path
     instance = Instance(str(instance_path))
     instance.assign_colours(load_colour_configuration(instance_path, instance.node_count))
@@ -253,7 +234,7 @@ def execute_test_case(test_case: TestCase) -> Tuple[Solution, List[WeightedCandi
         gamma_override=load_gamma_override(instance_path),
     )
     heuristic = ConstructiveHeuristic(
-        0.0,
+        alpha,
         test_case.beta_construction,
         test_case.beta_local_search,
         instance,
@@ -261,22 +242,47 @@ def execute_test_case(test_case: TestCase) -> Tuple[Solution, List[WeightedCandi
     )
 
     solution, candidates = heuristic.construct_biased_capacity_solution()
+    solution.reevaluate(alpha)
     solution, candidates = tabu_search_capacity(
         solution,
         candidates,
         test_case.max_iterations,
         heuristic,
     )
-    solution.reevaluate()
-    return deterministic_multi_start((solution, candidates), test_case, heuristic)
+    solution.reevaluate(alpha)
+    return deterministic_multi_start((solution, candidates), test_case, heuristic, alpha)
 
 
 def run(test_cases: Iterable[TestCase]) -> List[Tuple[TestCase, Solution, List[WeightedCandidate]]]:
-    results = []
+    results: List[Tuple[TestCase, Solution, List[WeightedCandidate]]] = []
     for test_case in test_cases:
         random.seed(test_case.seed)
-        solution, candidates = execute_test_case(test_case)
-        results.append((test_case, solution, candidates))
+        alpha_values: List[float] = []
+        pareto_history: List[Tuple[float, float, float]] = []
+        base_solution: Solution | None = None
+        base_candidates: List[WeightedCandidate] | None = None
+
+        current_alpha = 1.0
+        while True:
+            solution, candidates = execute_test_case(test_case, current_alpha)
+            solution.reevaluate(current_alpha)
+            alpha_values.append(current_alpha)
+            pareto_history.append(
+                (current_alpha, solution.cdp_objective, solution.symmetry_penalty)
+            )
+            if base_solution is None:
+                base_solution = solution
+                base_candidates = clone_weighted_candidates(candidates)
+            current_alpha = max(current_alpha - test_case.alpha_step, 0.0)
+            if math.isclose(alpha_values[-1], 0.0, abs_tol=1e-9):
+                break
+
+        if base_solution is None or base_candidates is None:
+            raise RuntimeError("No feasible solution generated for the provided test case.")
+
+        base_solution.alpha_history = alpha_values
+        base_solution.pareto_history = pareto_history
+        results.append((test_case, base_solution, base_candidates))
     return results
 
 

--- a/CDP/Solution.py
+++ b/CDP/Solution.py
@@ -18,17 +18,24 @@ class Solution:
     min_distance_vertex1: int = -1
     min_distance_vertex2: int = -1
     objective_value: float = field(init=False)
+    cdp_objective: float = field(init=False)
     capacity: float = 0.0
     time: float = 0.0
     symmetry_penalty: float = 0.0
     symmetry_breakdown: Dict[Tuple[str, str], float] = field(default_factory=dict)
+    symmetry_objective: float = 0.0
+    objective_alpha: float = 1.0
+    alpha_history: List[float] = field(default_factory=list)
+    pareto_history: List[Tuple[float, float, float]] = field(default_factory=list)
     reliability: Dict[int, float] = field(default_factory=lambda: {1: 0.0, 2: 0.0})
     stochastic_capacity: Dict[int, float] = field(default_factory=lambda: {1: 0.0, 2: 0.0})
     stochastic_objective: Dict[int, float] = field(default_factory=lambda: {1: 0.0, 2: 0.0})
     mean_stochastic_objective: Dict[int, float] = field(default_factory=lambda: {1: 0.0, 2: 0.0})
 
     def __post_init__(self) -> None:
-        self.objective_value = self.instance.sorted_edges[0].distance * 10
+        baseline = self.instance.sorted_edges[0].distance * 10
+        self.objective_value = baseline
+        self.cdp_objective = baseline
 
     def copy(self) -> "Solution":
         clone = Solution(self.instance)
@@ -36,10 +43,15 @@ class Solution:
         clone.min_distance_vertex1 = self.min_distance_vertex1
         clone.min_distance_vertex2 = self.min_distance_vertex2
         clone.objective_value = self.objective_value
+        clone.cdp_objective = self.cdp_objective
         clone.capacity = self.capacity
         clone.time = self.time
         clone.symmetry_penalty = self.symmetry_penalty
         clone.symmetry_breakdown = dict(self.symmetry_breakdown)
+        clone.symmetry_objective = self.symmetry_objective
+        clone.objective_alpha = self.objective_alpha
+        clone.alpha_history = list(self.alpha_history)
+        clone.pareto_history = list(self.pareto_history)
         clone.reliability = dict(self.reliability)
         clone.stochastic_capacity = dict(self.stochastic_capacity)
         clone.stochastic_objective = dict(self.stochastic_objective)
@@ -69,11 +81,15 @@ class Solution:
 
     def update_objective(self, vertex1: int, vertex2: int, distance: float) -> None:
         self.objective_value = distance
+        self.cdp_objective = distance
         self.min_distance_vertex1 = vertex1
         self.min_distance_vertex2 = vertex2
 
-    def evaluate_complete(self) -> float:
+    def evaluate_complete(self, alpha: float | None = None) -> float:
+        if alpha is not None:
+            self.objective_alpha = alpha
         self.objective_value = self.instance.sorted_edges[0].distance * 10
+        self.cdp_objective = self.objective_value
         for vertex1 in self.selected_vertices:
             for vertex2 in self.selected_vertices:
                 if vertex1 == vertex2:
@@ -81,11 +97,16 @@ class Solution:
                 distance = self.instance.distances[vertex1][vertex2]
                 if distance < self.objective_value:
                     self.objective_value = distance
+                    self.cdp_objective = distance
         self.evaluate_symmetry()
+        self.objective_value = self.weighted_objective()
         return self.objective_value
 
-    def reevaluate(self) -> None:
+    def reevaluate(self, alpha: float | None = None) -> None:
+        if alpha is not None:
+            self.objective_alpha = alpha
         self.objective_value = self.instance.sorted_edges[0].distance * 10
+        self.cdp_objective = self.objective_value
         for vertex1 in self.selected_vertices:
             for vertex2 in self.selected_vertices:
                 if vertex1 == vertex2:
@@ -95,7 +116,9 @@ class Solution:
                     self.objective_value = distance
                     self.min_distance_vertex1 = vertex1
                     self.min_distance_vertex2 = vertex2
+                    self.cdp_objective = distance
         self.evaluate_symmetry()
+        self.objective_value = self.weighted_objective()
 
     def evaluate_symmetry(self) -> float:
         """Update and return the symmetry penalty for the current selection."""
@@ -105,11 +128,15 @@ class Solution:
         )
         self.symmetry_penalty = penalty
         self.symmetry_breakdown = breakdown
+        self.symmetry_objective = penalty
         return self.symmetry_penalty
 
-    def weighted_objective(self, alpha: float) -> float:
+    def weighted_objective(self, alpha: float | None = None) -> float:
         """Return the scalarised objective balancing dispersion and symmetry."""
 
-        dispersion_value = self.objective_value if self.selected_vertices else 0.0
-        return alpha * dispersion_value - (1 - alpha) * self.symmetry_penalty
+        if alpha is not None:
+            self.objective_alpha = alpha
+        effective_alpha = self.objective_alpha
+        dispersion_value = self.cdp_objective if self.selected_vertices else 0.0
+        return effective_alpha * dispersion_value - (1 - effective_alpha) * self.symmetry_penalty
 


### PR DESCRIPTION
## Summary
- ensure solutions track separate CDP and symmetry objectives while storing Pareto history and alpha weights
- simplify constructive heuristic weight handling and update local searches and run loop to iterate deterministic alphas from 1 to 0

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb5847430c832b900254ecd277dd9a