### PR TITLE
Swap Pareto frontier axes and translate logs

### DIFF
--- a/CDP/Main.py
+++ b/CDP/Main.py
@@ -119,7 +119,7 @@ def resolve_instance_path(instance_reference: str) -> tuple[str, Path]:
     if reference_path.is_absolute():
         if not reference_path.exists():
             raise FileNotFoundError(
-                f"No se encontró la instancia solicitada en '{reference_path}'."
+                f"Requested instance '{reference_path}' was not found."
             )
         return reference_path.name, reference_path
 
@@ -130,8 +130,8 @@ def resolve_instance_path(instance_reference: str) -> tuple[str, Path]:
             return reference_path.name, candidate
 
     raise FileNotFoundError(
-        "No se encontró la instancia solicitada. "
-        f"Se buscó en: {', '.join(str((root / reference_path).resolve()) for root in search_roots)}."
+        "Requested instance was not found. "
+        f"Searched in: {', '.join(str((root / reference_path).resolve()) for root in search_roots)}."
     )
 
 
@@ -420,14 +420,14 @@ def main() -> None:
             )
         )
 
-        print(f"Frontera de Pareto para {test_case.instance_name} (seed={test_case.seed}):")
+        print(f"Pareto frontier for {test_case.instance_name} (seed={test_case.seed}):")
         print(
-            "  Referencia heurística sin simetría: "
-            f"objetivo_CDP={base_dispersion:.3f}, "
-            f"objetivo_simetría={base_penalty:.3f}"
+            "  Symmetry-agnostic heuristic reference: "
+            f"cdp_objective={base_dispersion:.3f}, "
+            f"symmetry_penalty={base_penalty:.3f}"
         )
         if using_history_front:
-            rows = [(entry[2], entry[1]) for entry in history_data]
+            rows = [(entry[1], entry[2]) for entry in history_data]
             labels = [f"α={entry[0]:.2f}" for entry in history_data]
         else:
             rows = pareto_points_to_rows(candidate_pool)
@@ -435,24 +435,24 @@ def main() -> None:
                 labels = alpha_labels
             else:
                 labels = [
-                    "Sin simetría",
-                    *[f"Iteración {index}" for index in range(1, len(rows))],
+                    "Baseline",
+                    *[f"Iteration {index}" for index in range(1, len(rows))],
                 ]
-        for label, (penalty, dispersion) in zip(labels, rows):
+        for label, (dispersion, penalty) in zip(labels, rows):
             print(
                 "  "
-                f"{label}: objetivo_CDP={dispersion:.3f}, "
-                f"objetivo_simetría={penalty:.3f}"
+                f"{label}: cdp_objective={dispersion:.3f}, "
+                f"symmetry_penalty={penalty:.3f}"
             )
         if not using_history_front and len(rows) == 1:
             print(
-                "  No se encontraron mejoras adicionales en la frontera con las "
-                "combinaciones de α evaluadas."
+                "  No additional improvements were found on the frontier for the "
+                "evaluated α combinations."
             )
         if pareto_plot_path is not None:
-            print(f"  Plot guardado en: {pareto_plot_path}")
+            print(f"  Plot saved to: {pareto_plot_path}")
         elif plot_error:
-            print(f"  No se generó plot: {plot_error}")
+            print(f"  Plot was not generated: {plot_error}")
 
 
 if __name__ == "__main__":

--- a/CDP/symmetry_integration.py
+++ b/CDP/symmetry_integration.py
@@ -290,14 +290,14 @@ def analyse_solution(
 
 
 def pareto_points_to_rows(candidates: Iterable[CandidateSolution]) -> List[Tuple[float, float]]:
-    """Return symmetry/CDP objective pairs for the provided candidates."""
+    """Return CDP/symmetry objective pairs for the provided candidates."""
 
     rows: List[Tuple[float, float]] = []
     for candidate in candidates:
         dispersion = (
             candidate.dispersion if math.isfinite(candidate.dispersion) else 0.0
         )
-        rows.append((candidate.symmetry_penalty, dispersion))
+        rows.append((dispersion, candidate.symmetry_penalty))
     return rows
 
 
@@ -337,32 +337,32 @@ def plot_pareto_front(
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     plt.figure(figsize=(8, 5))
-    penalties = [row[0] for row in rows]
-    dispersions = [row[1] for row in rows]
-    plt.plot(penalties, dispersions, marker="o", linestyle="-", color="#1f77b4")
+    dispersions = [row[0] for row in rows]
+    penalties = [row[1] for row in rows]
+    plt.plot(dispersions, penalties, marker="o", linestyle="-", color="#1f77b4")
     plt.scatter(
-        penalties[0],
         dispersions[0],
+        penalties[0],
         color="#d62728",
         marker="s",
         s=120,
-        label="Punto inicial",
+        label="Initial solution",
         zorder=3,
     )
     if len(rows) > 1:
         plt.scatter(
-            penalties[1:],
             dispersions[1:],
+            penalties[1:],
             color="#2ca02c",
             marker="o",
             s=80,
-            label="Frontera explorada",
+            label="Explored frontier",
             zorder=3,
         )
     if alpha_labels:
         if len(alpha_labels) != len(rows):
             raise ValueError("alpha_labels length must match the number of candidates.")
-        for label, x_val, y_val in zip(alpha_labels, penalties, dispersions):
+        for label, x_val, y_val in zip(alpha_labels, dispersions, penalties):
             plt.annotate(
                 label,
                 (x_val, y_val),
@@ -370,9 +370,9 @@ def plot_pareto_front(
                 xytext=(6, 6),
                 fontsize="small",
             )
-    plt.xlabel("Función objetivo de simetría (penalización)")
-    plt.ylabel("Función objetivo CDP (dispersión)")
-    plt.title("Frontera de Pareto CDP-Simetría")
+    plt.xlabel("CDP objective (dispersion)")
+    plt.ylabel("Symmetry penalty")
+    plt.title("CDP-Symmetry Pareto frontier")
     plt.grid(True, linestyle="--", alpha=0.4)
     plt.legend(loc="best")
     plt.tight_layout()
@@ -402,27 +402,27 @@ def plot_pareto_history(
     labels = [f"α={entry[0]:.2f}" for entry in history]
 
     plt.figure(figsize=(8, 5))
-    plt.plot(penalties, dispersions, marker="o", linestyle="-", color="#1f77b4")
+    plt.plot(dispersions, penalties, marker="o", linestyle="-", color="#1f77b4")
     plt.scatter(
-        penalties[0],
         dispersions[0],
+        penalties[0],
         color="#d62728",
         marker="s",
         s=120,
-        label="Punto inicial",
+        label="Initial solution",
         zorder=3,
     )
     if len(history) > 1:
         plt.scatter(
-            penalties[1:],
             dispersions[1:],
+            penalties[1:],
             color="#2ca02c",
             marker="o",
             s=80,
-            label="Frontera explorada",
+            label="Explored frontier",
             zorder=3,
         )
-    for label, x_val, y_val in zip(labels, penalties, dispersions):
+    for label, x_val, y_val in zip(labels, dispersions, penalties):
         plt.annotate(
             label,
             (x_val, y_val),
@@ -430,9 +430,9 @@ def plot_pareto_history(
             xytext=(6, 6),
             fontsize="small",
         )
-    plt.xlabel("Función objetivo de simetría (penalización)")
-    plt.ylabel("Función objetivo CDP (dispersión)")
-    plt.title("Frontera de Pareto CDP-Simetría")
+    plt.xlabel("CDP objective (dispersion)")
+    plt.ylabel("Symmetry penalty")
+    plt.title("CDP-Symmetry Pareto frontier")
     plt.grid(True, linestyle="--", alpha=0.4)
     plt.legend(loc="best")
     plt.tight_layout()

--- a/test/test_symmetry_integration.py
+++ b/test/test_symmetry_integration.py
@@ -179,9 +179,9 @@ class TestSymmetryIntegration(unittest.TestCase):
             self.assertTrue(generated.exists())
             points = pareto_points_to_rows([base_candidate, *frontier])
             self.assertTrue(points)
-            first_penalty, first_dispersion = points[0]
-            self.assertGreaterEqual(first_penalty, 0.0)
+            first_dispersion, first_penalty = points[0]
             self.assertGreaterEqual(first_dispersion, 0.0)
+            self.assertGreaterEqual(first_penalty, 0.0)
 
     def test_default_alpha_schedule_generates_expected_pairs(self) -> None:
         schedule = default_alpha_schedule(step=0.25)


### PR DESCRIPTION
## Summary
- display the CDP objective on the x-axis and the symmetry penalty on the y-axis for Pareto frontier plots
- translate Pareto-related console messages and file lookup errors to English while keeping default labelling coherent with the new axis order
- update symmetry plotting tests to reflect the revised data ordering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb6655d040832bb3ce82c34a8a1dd9