### PR TITLE
Preserve raw dispersion values in Pareto frontier logs

### DIFF
--- a/CDP/Main.py
+++ b/CDP/Main.py
@@ -301,11 +301,7 @@ def main() -> None:
             steps=6,
             alpha_step=test_case.alpha_step,
         )
-        base_dispersion = (
-            analysis.base_solution.dispersion
-            if math.isfinite(analysis.base_solution.dispersion)
-            else 0.0
-        )
+        base_dispersion = analysis.base_solution.dispersion
         base_penalty = analysis.base_solution.symmetry_penalty
         pareto_plot_path: Path | None = None
         plot_error: str | None = None
@@ -333,9 +329,7 @@ def main() -> None:
                     ),
                 ),
             )
-            best_dispersion = (
-                best_candidate.dispersion if math.isfinite(best_candidate.dispersion) else 0.0
-            )
+            best_dispersion = best_candidate.dispersion
             best_penalty = best_candidate.symmetry_penalty
         else:
             candidate_pool = [analysis.base_solution]

--- a/CDP/symmetry_integration.py
+++ b/CDP/symmetry_integration.py
@@ -294,10 +294,7 @@ def pareto_points_to_rows(candidates: Iterable[CandidateSolution]) -> List[Tuple
 
     rows: List[Tuple[float, float]] = []
     for candidate in candidates:
-        dispersion = (
-            candidate.dispersion if math.isfinite(candidate.dispersion) else 0.0
-        )
-        rows.append((dispersion, candidate.symmetry_penalty))
+        rows.append((candidate.dispersion, candidate.symmetry_penalty))
     return rows
 
 


### PR DESCRIPTION
## Summary
- stop clamping Pareto frontier dispersion values to zero when they are infinite
- report the base and best dispersions in the Pareto summary using their raw values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f278e338c0832b8c922360574fc594