### PR TITLE
Add sanity checks for weighted objective consistency

### DIFF
--- a/CDP/Main.py
+++ b/CDP/Main.py
@@ -278,6 +278,31 @@ def perform_sanity_check(results: Iterable[Tuple[TestCase, Solution, List[Weight
         if not solution.is_feasible():
             raise RuntimeError("Generated solution violates the minimum capacity constraint.")
 
+        previous_value = solution.objective_value
+        previous_alpha = solution.objective_alpha
+        recomputed_value = solution.evaluate_complete(previous_alpha)
+
+        if not math.isclose(
+            previous_value,
+            recomputed_value,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise RuntimeError(
+                "Solution objective mismatch after recomputation; the weighted objective "
+                "is not consistent with the stored dispersion and symmetry metrics."
+            )
+
+        if math.isclose(previous_alpha, 1.0, abs_tol=1e-9) and not math.isclose(
+            solution.cdp_objective,
+            recomputed_value,
+            rel_tol=1e-9,
+            abs_tol=1e-9,
+        ):
+            raise RuntimeError(
+                "For α=1 the objective function should coincide with the dispersion value."
+            )
+
 
 def main() -> None:
     tests = load_test_cases("run")

--- a/test/test_main_sanity.py
+++ b/test/test_main_sanity.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "CDP"))
+
+from Main import perform_sanity_check
+from Instance import Instance
+from Solution import Solution
+from objects import TestCase as BenchmarkTestCase
+
+
+class TestMainSanity(unittest.TestCase):
+    """Validate the final sanity checks performed after solving instances."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        instance_path = ROOT / "CDP" / "sample_instance.txt"
+        cls.instance = Instance(str(instance_path))
+        cls.instance.assign_colours(["red", "blue", "green"])
+        cls.instance.set_symmetry_parameters(lambda_penalty=0.2)
+        cls.test_case = BenchmarkTestCase(
+            instance_name="sample",
+            instance_path=instance_path,
+            seed=0,
+            max_time=0,
+            beta_construction=0.5,
+            beta_local_search=0.5,
+            max_iterations=0,
+            weight=0.5,
+        )
+
+    def _build_solution(self) -> Solution:
+        solution = Solution(self.instance)
+        for vertex in range(self.instance.node_count):
+            solution.add_vertex(vertex)
+        solution.reevaluate(alpha=0.75)
+        return solution
+
+    def test_perform_sanity_check_detects_inconsistent_objective(self) -> None:
+        solution = self._build_solution()
+        solution.objective_value += 1.0
+        with self.assertRaises(RuntimeError):
+            perform_sanity_check([(self.test_case, solution, [])])
+
+    def test_perform_sanity_check_enforces_alpha_one_dispersion(self) -> None:
+        solution = self._build_solution()
+        solution.reevaluate(alpha=1.0)
+        perform_sanity_check([(self.test_case, solution, [])])
+        self.assertAlmostEqual(solution.objective_value, solution.cdp_objective)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    unittest.main()


### PR DESCRIPTION
## Summary
- recompute the weighted objective during the final sanity check to ensure feasibility and consistency
- raise clear errors when the alpha=1.0 objective diverges from the dispersion value
- cover the new validation logic with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f27eb762d4832b8537d09a09abe3e7